### PR TITLE
Use the new edit_settings command for better options menu

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -16,70 +16,22 @@
                         "children":
                         [
                             {
-                                "command": "open_file", "args":
+                                "caption": "Settings",
+                                "command": "edit_settings", "args":
                                 {
-                                    "file": "${packages}/FuzzyFilePath/FuzzyFilePath.sublime-settings"
-                                },
-                                "caption": "Settings – Default"
-                            },
-                            {
-                                "command": "open_file", "args":
-                                {
-                                    "file": "${packages}/User/FuzzyFilePath.sublime-settings"
-                                },
-                                "caption": "Settings – User"
+                                    "base_file": "${packages}/FuzzyFilePath/FuzzyFilePath.sublime-settings",
+                                    "default": "{\n\t$0\n}\n"
+                                }
                             },
                             { "caption": "-" },
-                            { "caption": "-" },
                             {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/FuzzyFilePath/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/FuzzyFilePath/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/FuzzyFilePath/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            { "caption": "-" }
+                                "caption": "Key Bindings",
+                                "command": "edit_settings", "args":
+                                {
+                                    "base_file": "${packages}/FuzzyFilePath/Default ($platform).sublime-keymap",
+                                    "default": "[\n\t$0\n]\n"
+                                }
+                            }
                         ]
                     }
                 ]


### PR DESCRIPTION
I changed the options to use the new command so they open nicely side-by-side in a new window now.

This requires at least Sublime Text 3 r3124. Not sure if that'll be an issue?
ST3 users are probably on the latest version, but I guess it'll error out in ST2