### PR TITLE
New setting to add more scopes to the defaults

### DIFF
--- a/FuzzyFilePath.sublime-settings
+++ b/FuzzyFilePath.sublime-settings
@@ -14,6 +14,8 @@
 	"log": false,
 	// LIST OF TRIGGERS FOR AUTO COMPLETION
 	// - setting "scopes" in user settings will override all other scopes.
+	// - create "additional_scopes" in user settings to add more scopes instead.
+	//   they will be added after the existing scopes.
 	// - triggers are evaluated in given order. First match wins
 	// - specialize trigger by 1. scope 2. prefix, style and/or tagname
 	// - command (insert_path) still requires a trigger
@@ -240,6 +242,11 @@
 		    "auto": false,
 		    "extensions": ["js", "html", "css", "scss", "less", "png", "gif", "jpeg", "jpg", "svg"],
 		    "relative": true
+		},
+	],
+	"additional_scopes": [
+		{
+
 		}
 	]
 }

--- a/common/config.py
+++ b/common/config.py
@@ -16,6 +16,7 @@ config = {
 	"disable_keymap_actions": False,
 	"auto_trigger": True,
 	"trigger": [],
+	"additional_scopes": [],
 	"exclude_folders": ["node\\_modules", "bower\\_components/.*/bower\\_components"],
 
 	"post_insert_move_characters": "^[\"\'\);]*"

--- a/common/settings.py
+++ b/common/settings.py
@@ -73,6 +73,7 @@ def get_base_settings(config):
     user_settings = sublime.load_settings(config["ffp_settings_file"])
     # Note: user_settings is of class Settings
     user_settings = merge(config, user_settings)
+    user_settings = merge_scopes(user_settings)
     return sanitize(user_settings)
 
 
@@ -96,6 +97,16 @@ def merge(settings, overwrite={}):
         result[key] = overwrite.get(mappedKey, settings.get(key))
 
     return result
+
+
+def merge_scopes(settings):
+    """Merge triggers from 'additional_scopes' in user settings to the main triggers, if present"""
+    triggers = settings.get("trigger")
+    additional_scopes = settings.get("additional_scopes", [])
+    for trigger in additional_scopes:
+        triggers.append(trigger)
+    settings["trigger"] = triggers
+    return settings
 
 
 # @TODO improve memory


### PR DESCRIPTION
I'm a bit weary of replacing the whole scopes setting to add my own stuff to it in case it changes in the future, so I came up with this.
It'll merge the new `additional_scopes` to the existing ones, if it's there.

One thing I wasn't sure about was the naming. They're still called scopes in the settings instead of triggers so I went with `additional_scopes` as the name.

No problem if this isn't something you want to add! 😃